### PR TITLE
refactor: 홈 ui 수정

### DIFF
--- a/feature/home/src/main/java/com/teamoffroad/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/teamoffroad/feature/home/HomeScreen.kt
@@ -35,14 +35,16 @@ internal fun HomeScreen(
 ) {
     Surface(
         modifier = Modifier
+            .padding(bottom = 74.dp)
             .fillMaxSize()
             .verticalScroll(rememberScrollState()),
         color = Main1
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
-            UsersAdventuresInformation(modifier = Modifier)
+            UsersAdventuresInformation(modifier = Modifier.weight(1f))
             Spacer(modifier = Modifier.padding(top = 12.dp))
             UsersQuestInformation()
+            Spacer(modifier = Modifier.padding(top = 34.dp))
         }
     }
 }
@@ -56,16 +58,23 @@ private fun UsersAdventuresInformation(modifier: Modifier = Modifier) {
             NicknameText("비포장도로")
             CharacterItem().CharacterNameText("오푸")
         }
-        Box {
-            Box(
-                modifier = Modifier.fillMaxWidth(),
-                contentAlignment = Alignment.TopEnd
-            ) {
-                HomeBackground()
-                HomeIcons()
-            }
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.TopEnd
+        ) {
+            HomeBackground()
+            HomeIcons()
+        }
+
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                //.fillMaxHeight()
+                .align(Alignment.BottomCenter)
+        ) {
             CharacterItem().CharacterImage()
         }
+
     }
     Spacer(modifier = Modifier.padding(18.dp))
     CharacterItem().EmblemNameText(Modifier)

--- a/feature/home/src/main/res/drawable/ic_home_download.xml
+++ b/feature/home/src/main/res/drawable/ic_home_download.xml
@@ -1,22 +1,22 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="49dp"
-    android:height="50dp"
-    android:viewportWidth="49"
-    android:viewportHeight="50">
+    android:width="48dp"
+    android:height="49dp"
+    android:viewportWidth="48"
+    android:viewportHeight="49">
   <group>
     <clip-path
-        android:pathData="M0.084,0.635h48v48h-48z"/>
+        android:pathData="M0,0h48v48h-48z"/>
     <path
-        android:pathData="M24.084,4.635L24.084,4.635A20,20 0,0 1,44.084 24.635L44.084,24.635A20,20 0,0 1,24.084 44.635L24.084,44.635A20,20 0,0 1,4.084 24.635L4.084,24.635A20,20 0,0 1,24.084 4.635z"
+        android:pathData="M24,4L24,4A20,20 0,0 1,44 24L44,24A20,20 0,0 1,24 44L24,44A20,20 0,0 1,4 24L4,24A20,20 0,0 1,24 4z"
         android:fillColor="#ffffff"/>
     <path
         android:strokeWidth="1"
-        android:pathData="M24.084,5.135L24.084,5.135A19.5,19.5 0,0 1,43.584 24.635L43.584,24.635A19.5,19.5 0,0 1,24.084 44.135L24.084,44.135A19.5,19.5 0,0 1,4.584 24.635L4.584,24.635A19.5,19.5 0,0 1,24.084 5.135z"
+        android:pathData="M24,4.5L24,4.5A19.5,19.5 0,0 1,43.5 24L43.5,24A19.5,19.5 0,0 1,24 43.5L24,43.5A19.5,19.5 0,0 1,4.5 24L4.5,24A19.5,19.5 0,0 1,24 4.5z"
         android:strokeAlpha="0.15"
         android:fillColor="#00000000"
         android:strokeColor="#000000"/>
     <path
-        android:pathData="M18.744,32.885H29.744M24.244,16.385V29.218M24.244,29.218L28.827,24.635M24.244,29.218L19.661,24.635"
+        android:pathData="M18.66,32.25H29.66M24.16,15.75V28.583M24.16,28.583L28.743,24M24.16,28.583L19.577,24"
         android:strokeLineJoin="round"
         android:strokeWidth="2"
         android:fillColor="#00000000"


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #49 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 홈 다운로드 아이콘 변경 적용
- 홈 요소들이 bottom에서 34.dp 띄워지게 했고, 캐릭터 위치를 주황색 칭호 변경 버튼을 기준으로 padding 값을 넣어 위치시켰습니다. 아요 개발자님이랑 맞추었고, 이후에 로티 파일 나와서 위치가 애매하면 그때 변경하기로 했습니다. 

## 📷𝘚𝘤reenshot
<img width="333" alt="스크린샷 2024-07-15 오후 5 45 10" src="https://github.com/user-attachments/assets/7b3989b5-786a-4922-9743-1b628c0d8f70">
𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
궁금한점: 그 바텀네비의 height가 74.dp 라서 일단 home screen에서만 적용시켰는데 이거를 전체적으로 적용시키려면 어디에다가 작성해야 할지 잘 모르겠슴다..



