### PR TITLE
refactor: 퀘스트 진행도 및 칭호 변경

### DIFF
--- a/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/HomeScreen.kt
+++ b/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/HomeScreen.kt
@@ -59,6 +59,7 @@ fun HomeScreen(
         Surface(
             modifier = Modifier
                 .padding(bottom = 74.dp)
+                .navigationBarsPadding()
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState()),
             color = Main1

--- a/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/HomeScreen.kt
+++ b/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/HomeScreen.kt
@@ -50,19 +50,15 @@ fun HomeScreen(
     val viewModel: HomeViewModel = hiltViewModel()
 
     LaunchedEffect(Unit) {
-        if (category != "NONE") viewModel.updateCategory(category)
-        if (category.isBlank()) {
-            viewModel.getUsersAdventuresInformations("NONE")
-        } else {
-            viewModel.getUsersAdventuresInformations(category)
-        }
+        viewModel.updateCategory(category.ifBlank { "NONE" })
+        viewModel.getUsersAdventuresInformations(viewModel.category.value)
         viewModel.getUserQuests()
     }
+
     FadeInWrapper {
         Surface(
             modifier = Modifier
                 .padding(bottom = 74.dp)
-                .navigationBarsPadding()
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState()),
             color = Main1

--- a/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/HomeScreen.kt
+++ b/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/HomeScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.teamoffroad.core.designsystem.component.FadeInWrapper
 import com.teamoffroad.core.common.util.OnBackButtonListener
 import com.teamoffroad.core.designsystem.component.OffroadActionBar
 import com.teamoffroad.core.designsystem.component.StaticAnimationWrapper

--- a/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/HomeScreen.kt
+++ b/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/HomeScreen.kt
@@ -34,6 +34,7 @@ import com.teamoffroad.core.designsystem.theme.Main1
 import com.teamoffroad.core.designsystem.theme.OffroadTheme
 import com.teamoffroad.feature.home.domain.model.UserQuests
 import com.teamoffroad.feature.home.presentation.component.HomeIcons
+import com.teamoffroad.feature.home.presentation.component.UiState
 import com.teamoffroad.feature.home.presentation.component.character.CharacterItem
 import com.teamoffroad.feature.home.presentation.component.quest.progressbar.CloseCompleteRequest
 import com.teamoffroad.feature.home.presentation.component.quest.progressbar.RecentQuest

--- a/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/HomeViewModel.kt
@@ -6,6 +6,8 @@ import com.teamoffroad.feature.home.domain.model.Emblem
 import com.teamoffroad.feature.home.domain.model.UserQuests
 import com.teamoffroad.feature.home.domain.model.UsersAdventuresInformations
 import com.teamoffroad.feature.home.domain.repository.UserRepository
+import com.teamoffroad.feature.home.presentation.component.UiState
+import com.teamoffroad.feature.home.presentation.component.getErrorMessage
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -16,7 +18,8 @@ import javax.inject.Inject
 class HomeViewModel @Inject constructor(
     private val userRepository: UserRepository,
 ) : ViewModel() {
-    private val _getUsersAdventuresInformationsState = MutableStateFlow<UiState<UsersAdventuresInformations>>(UiState.Loading)
+    private val _getUsersAdventuresInformationsState = MutableStateFlow<UiState<UsersAdventuresInformations>>(
+        UiState.Loading)
     val getUsersAdventuresInformationsState = _getUsersAdventuresInformationsState.asStateFlow()
 
     private val _selectedEmblem = MutableStateFlow("")

--- a/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/component/ErrorMessage.kt
+++ b/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/component/ErrorMessage.kt
@@ -1,6 +1,7 @@
-package com.teamoffroad.feature.home.presentation
+package com.teamoffroad.feature.home.presentation.component
 
 import com.google.gson.Gson
+import com.teamoffroad.feature.home.presentation.model.ErrorMessageModel
 import retrofit2.HttpException
 
 fun getErrorMessage(t: Any): String {

--- a/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/component/UiState.kt
+++ b/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/component/UiState.kt
@@ -1,4 +1,4 @@
-package com.teamoffroad.feature.home.presentation
+package com.teamoffroad.feature.home.presentation.component
 
 sealed interface UiState<out T> {
 

--- a/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/component/character/CharacterItem.kt
+++ b/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/component/character/CharacterItem.kt
@@ -44,7 +44,7 @@ import com.teamoffroad.core.designsystem.theme.OffroadTheme
 import com.teamoffroad.core.designsystem.theme.Sub
 import com.teamoffroad.core.designsystem.theme.White
 import com.teamoffroad.feature.home.presentation.HomeViewModel
-import com.teamoffroad.feature.home.presentation.UiState
+import com.teamoffroad.feature.home.presentation.component.UiState
 import com.teamoffroad.feature.home.presentation.component.dialog.ChangeEmblemDialog
 import com.teamoffroad.feature.home.presentation.model.UserChangeEmblemDialogStateModel
 import com.teamoffroad.offroad.feature.home.R
@@ -153,7 +153,7 @@ class CharacterItem {
             remember { mutableStateOf<UserChangeEmblemDialogStateModel?>(null) }
         val interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
 
-        val showChangeEmblemDialog = remember { mutableStateOf(false) }
+        val isChangeEmblemDialogShown = remember { mutableStateOf(false) }
 
         when (emblemState) {
             is UiState.Success -> null
@@ -185,17 +185,17 @@ class CharacterItem {
                     .clickableWithoutRipple(
                         interactionSource
                     ) {
-                        showChangeEmblemDialog.value = true
+                        isChangeEmblemDialogShown.value = true
                     }
             )
 
-            if (showChangeEmblemDialog.value) {
+            if (isChangeEmblemDialogShown.value) {
                 ChangeEmblemDialog(
-                    showDialog = showChangeEmblemDialog,
+                    showDialog = isChangeEmblemDialogShown,
                     userChangeEmblemDialogStateModel = userChangeEmblemDialogStateModel,
                     originEmblem = userEmblem,
                     onClickCancel = {
-                        showChangeEmblemDialog.value = false
+                        isChangeEmblemDialogShown.value = false
                         userChangeEmblemDialogStateModel.value?.onClickCancel
                     },
                     onCharacterChange = { emblem ->

--- a/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/component/character/CharacterItem.kt
+++ b/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/component/character/CharacterItem.kt
@@ -45,8 +45,8 @@ import com.teamoffroad.core.designsystem.theme.Sub
 import com.teamoffroad.core.designsystem.theme.White
 import com.teamoffroad.feature.home.presentation.HomeViewModel
 import com.teamoffroad.feature.home.presentation.UiState
-import com.teamoffroad.feature.home.presentation.component.dialog.OffroadDialog
-import com.teamoffroad.feature.home.presentation.model.CustomTitleDialogStateModel
+import com.teamoffroad.feature.home.presentation.component.dialog.ChangeEmblemDialog
+import com.teamoffroad.feature.home.presentation.model.UserChangeEmblemDialogStateModel
 import com.teamoffroad.offroad.feature.home.R
 
 class CharacterItem {
@@ -148,12 +148,12 @@ class CharacterItem {
     ) {
         val viewModel: HomeViewModel = hiltViewModel()
         val emblemState = viewModel.patchEmblemState.collectAsState(initial = UiState.Loading).value
-        val selectedEmblem = viewModel.selectedEmblem.collectAsState().value
-        val customTitleDialogStateModel =
-            remember { mutableStateOf<CustomTitleDialogStateModel?>(null) }
+        val userEmblem = viewModel.selectedEmblem.collectAsState().value
+        val userChangeEmblemDialogStateModel =
+            remember { mutableStateOf<UserChangeEmblemDialogStateModel?>(null) }
         val interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
 
-        val showDialog = remember { mutableStateOf(false) }
+        val showChangeEmblemDialog = remember { mutableStateOf(false) }
 
         when (emblemState) {
             is UiState.Success -> null
@@ -172,7 +172,7 @@ class CharacterItem {
             contentAlignment = Alignment.CenterEnd
         ) {
             OffroadTagItem(
-                text = selectedEmblem,
+                text = userEmblem,
                 textColor = White,
                 style = OffroadTheme.typography.subtitle2Semibold,
                 backgroundColor = Sub
@@ -185,16 +185,18 @@ class CharacterItem {
                     .clickableWithoutRipple(
                         interactionSource
                     ) {
-                        showDialog.value = true
+                        showChangeEmblemDialog.value = true
                     }
             )
-            if (showDialog.value) {
-                OffroadDialog(
-                    showDialog,
-                    customTitleDialogStateModel,
+
+            if (showChangeEmblemDialog.value) {
+                ChangeEmblemDialog(
+                    showDialog = showChangeEmblemDialog,
+                    userChangeEmblemDialogStateModel = userChangeEmblemDialogStateModel,
+                    originEmblem = userEmblem,
                     onClickCancel = {
-                        showDialog.value = false
-                        customTitleDialogStateModel.value?.onClickCancel
+                        showChangeEmblemDialog.value = false
+                        userChangeEmblemDialogStateModel.value?.onClickCancel
                     },
                     onCharacterChange = { emblem ->
                         if (emblem != null) {

--- a/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/component/dialog/ChangeEmblemDialog.kt
+++ b/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/component/dialog/ChangeEmblemDialog.kt
@@ -1,7 +1,6 @@
 package com.teamoffroad.feature.home.presentation.component.dialog
 
 import android.annotation.SuppressLint
-import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -200,7 +199,7 @@ private fun CharacterTitle(
                         when (selectedChangeEmblemState) {
                             SelectedEmblemState.SAME_WITH_ORIGIN_EMBLEM -> {
                                 selectedEmblemData.value = null
-                                clickedOriginEmblem.value = clickedOriginEmblem.value.not() // 아닌거 클릭 후 origin emblem 클릭하면 둘다 활성화
+                                clickedOriginEmblem.value = clickedOriginEmblem.value.not()
                             }
 
                             SelectedEmblemState.SAME_WITH_SELECTED_CHANGE_EMBLEM -> {

--- a/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/component/dialog/ChangeEmblemDialog.kt
+++ b/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/component/dialog/ChangeEmblemDialog.kt
@@ -41,7 +41,7 @@ import com.teamoffroad.core.designsystem.theme.Sub
 import com.teamoffroad.core.designsystem.theme.White
 import com.teamoffroad.feature.home.domain.model.Emblem
 import com.teamoffroad.feature.home.presentation.HomeViewModel
-import com.teamoffroad.feature.home.presentation.UiState
+import com.teamoffroad.feature.home.presentation.component.UiState
 import com.teamoffroad.feature.home.presentation.model.UserChangeEmblemDialogStateModel
 import com.teamoffroad.offroad.feature.home.R
 

--- a/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/component/dialog/SelectedEmblemState.kt
+++ b/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/component/dialog/SelectedEmblemState.kt
@@ -1,0 +1,7 @@
+package com.teamoffroad.feature.home.presentation.component.dialog
+
+enum class SelectedEmblemState {
+    SAME_WITH_ORIGIN_EMBLEM,
+    SAME_WITH_SELECTED_CHANGE_EMBLEM,
+    SELECTED_CHANGE_EMBLEM
+}

--- a/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/model/ErrorMessageModel.kt
+++ b/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/model/ErrorMessageModel.kt
@@ -1,4 +1,4 @@
-package com.teamoffroad.feature.home.presentation
+package com.teamoffroad.feature.home.presentation.model
 
 data class ErrorMessageModel(
     val message: String,

--- a/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/model/UserChangeEmblemDialogStateModel.kt
+++ b/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/model/UserChangeEmblemDialogStateModel.kt
@@ -1,6 +1,6 @@
 package com.teamoffroad.feature.home.presentation.model
 
-data class CustomTitleDialogStateModel(
+data class UserChangeEmblemDialogStateModel(
     val emblemCode: String = "",
     val emblemName: String = "",
     val onClickConfirm: () -> Unit = {},


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #115 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 기존에 선택한 칭호 색칠하기 -> 중복된 칭호 없으므로 이름 자체로 구별해 활성화 여부 구분
- 기존에 선택한 칭호의 경우 '바꾸기' 버튼 클릭 비활성화


## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
https://github.com/user-attachments/assets/4f4fa9e9-1e58-4313-a753-be20a532afa0


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
113, 116 PR merge 후에 merge 하겠습니다



