### PR TITLE
feature: 다이어리 FCM 연결

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -65,7 +65,7 @@
                 android:resource="@xml/file_paths" />
         </provider>
         <receiver
-            android:name="com.teamoffroad.feature.main.CharacterChatBroadcastReceiver"
+            android:name="com.teamoffroad.feature.main.FcmBroadcastReceiver"
             android:exported="false"
             tools:ignore="Instantiatable">
             <intent-filter>

--- a/app/src/main/java/com/teamoffroad/offroad.app/OffRoadMessagingService.kt
+++ b/app/src/main/java/com/teamoffroad/offroad.app/OffRoadMessagingService.kt
@@ -15,6 +15,7 @@ import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.teamoffroad.core.common.domain.model.FcmNotificationKey.ACTION_ANNOUNCEMENT_FOREGROUND
 import com.teamoffroad.core.common.domain.model.FcmNotificationKey.ACTION_CHARACTER_CHAT_FOREGROUND
+import com.teamoffroad.core.common.domain.model.FcmNotificationKey.ACTION_DIARY_CREATE_FOREGROUND
 import com.teamoffroad.core.common.domain.model.FcmNotificationKey.CHANNEL_ID
 import com.teamoffroad.core.common.domain.model.FcmNotificationKey.KEY_BODY
 import com.teamoffroad.core.common.domain.model.FcmNotificationKey.KEY_ID
@@ -22,7 +23,9 @@ import com.teamoffroad.core.common.domain.model.FcmNotificationKey.KEY_IMAGE
 import com.teamoffroad.core.common.domain.model.FcmNotificationKey.KEY_TITLE
 import com.teamoffroad.core.common.domain.model.FcmNotificationKey.KEY_TYPE
 import com.teamoffroad.core.common.domain.model.FcmNotificationKey.NOTICE
+import com.teamoffroad.core.common.domain.model.FcmNotificationKey.TYPE_ANNOUNCEMENT
 import com.teamoffroad.core.common.domain.model.FcmNotificationKey.TYPE_CHARACTER_CHAT
+import com.teamoffroad.core.common.domain.model.FcmNotificationKey.TYPE_DIARY_CREATE
 import com.teamoffroad.core.common.domain.repository.TokenRepository
 import com.teamoffroad.core.common.util.ActivityLifecycleHandler
 import com.teamoffroad.feature.main.MainActivity
@@ -45,7 +48,7 @@ class OffRoadMessagingService : FirebaseMessagingService() {
         super.onMessageReceived(remoteMessage)
         if (remoteMessage.data.isNotEmpty()) {
             if (ActivityLifecycleHandler.isAppInForeground) {
-                if (remoteMessage.data[KEY_TYPE] != TYPE_CHARACTER_CHAT)
+                if (remoteMessage.data[KEY_TYPE] == TYPE_ANNOUNCEMENT)
                     sendNotification(remoteMessage, true)
                 else {
                     sendCharacterChatNotificationInForeground(remoteMessage)
@@ -164,13 +167,21 @@ class OffRoadMessagingService : FirebaseMessagingService() {
     private fun sendCharacterChatNotificationInForeground(
         remoteMessage: RemoteMessage,
     ) {
-        val broadCastIntent =
-            Intent(ACTION_CHARACTER_CHAT_FOREGROUND).apply {
-                putExtra(KEY_TITLE, remoteMessage.data[KEY_TITLE])
-                putExtra(KEY_BODY, remoteMessage.data[KEY_BODY])
-                putExtra(KEY_TYPE, remoteMessage.data[KEY_TYPE])
+        when (remoteMessage.data[KEY_TYPE]) {
+            TYPE_CHARACTER_CHAT -> {
+                val broadCastIntent =
+                    Intent(ACTION_CHARACTER_CHAT_FOREGROUND).apply {
+                        putExtra(KEY_TITLE, remoteMessage.data[KEY_TITLE])
+                        putExtra(KEY_BODY, remoteMessage.data[KEY_BODY])
+                        putExtra(KEY_TYPE, remoteMessage.data[KEY_TYPE])
+                    }
+                sendBroadcast(broadCastIntent)
             }
-        sendBroadcast(broadCastIntent)
+
+            TYPE_DIARY_CREATE -> {
+                sendBroadcast(Intent(ACTION_DIARY_CREATE_FOREGROUND))
+            }
+        }
     }
 
     private fun showNotification(

--- a/core/common/src/main/java/com/teamoffroad/core/common/domain/model/FcmNotificationKey.kt
+++ b/core/common/src/main/java/com/teamoffroad/core/common/domain/model/FcmNotificationKey.kt
@@ -10,7 +10,9 @@ object FcmNotificationKey {
     const val KEY_ID = "announcementId"
     const val TYPE_CHARACTER_CHAT = "CHARACTER_CHAT"
     const val TYPE_ANNOUNCEMENT = "ANNOUNCEMENT_REDIRECT"
+    const val TYPE_DIARY_CREATE = "MEMBER_DIARY_CREATE"
     const val ACTION_ANNOUNCEMENT_FOREGROUND = "com.teamoffroad.offroad.app.ANNOUNCEMENT_FOREGROUND"
     const val ACTION_CHARACTER_CHAT_FOREGROUND =
         "com.teamoffroad.offroad.app.CHARACTER_CHAT_FOREGROUND"
+    const val ACTION_DIARY_CREATE_FOREGROUND = "com.teamoffroad.offroad.app.DIARY_CREATE_FOREGROUND"
 }

--- a/core/common/src/main/java/com/teamoffroad/core/common/domain/model/NotificationEvent.kt
+++ b/core/common/src/main/java/com/teamoffroad/core/common/domain/model/NotificationEvent.kt
@@ -5,3 +5,7 @@ data class NotificationEvent(
     val characterContent: String?,
     val type: String?,
 )
+
+data class DiaryCreateNotificationEvent(
+    val state: Boolean,
+)

--- a/core/designsystem/src/main/java/com/teamoffroad/core/designsystem/component/OrbDialog.kt
+++ b/core/designsystem/src/main/java/com/teamoffroad/core/designsystem/component/OrbDialog.kt
@@ -1,4 +1,4 @@
-package com.teamoffroad.feature.mypage.presentation.component
+package com.teamoffroad.core.designsystem.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
@@ -20,14 +19,13 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import com.teamoffroad.core.designsystem.component.clickableWithoutRipple
 import com.teamoffroad.core.designsystem.theme.Main2
 import com.teamoffroad.core.designsystem.theme.Main3
 import com.teamoffroad.core.designsystem.theme.OffroadTheme
 import com.teamoffroad.core.designsystem.theme.White
 
 @Composable
-fun DiaryTimeDialog(
+fun OrbDialog(
     title: String,
     content: String,
     cancelButtonText: String,
@@ -52,45 +50,33 @@ fun DiaryTimeDialog(
                     .padding(vertical = 22.dp, horizontal = 40.dp)
             ) {
                 when (isNext) {
-                    true -> {
-                        Text(
-                            text = title,
-                            color = Main2,
-                            style = OffroadTheme.typography.title,
-                            modifier = Modifier
-                                .align(Alignment.CenterHorizontally)
-                                .padding(bottom = 20.dp)
-                        )
-                        Text(
-                            text = content,
-                            color = Main2,
-                            style = OffroadTheme.typography.textRegular,
-                            modifier = Modifier
-                                .align(Alignment.CenterHorizontally)
-                                .height(42.dp)
-                        )
-                    }
+                    true -> Text(
+                        text = title,
+                        color = Main2,
+                        style = OffroadTheme.typography.title,
+                        modifier = Modifier
+                            .align(Alignment.CenterHorizontally)
+                            .padding(bottom = 20.dp)
+                    )
 
-                    false -> {
-                        Text(
-                            text = title,
-                            color = Main2,
-                            style = OffroadTheme.typography.textRegular,
-                            modifier = Modifier
-                                .align(Alignment.CenterHorizontally)
-                                .padding(top = 10.dp, bottom = 6.dp)
-                        )
-                        Text(
-                            text = content,
-                            color = Main2,
-                            style = OffroadTheme.typography.textRegular,
-                            modifier = Modifier
-                                .align(Alignment.CenterHorizontally)
-                                .height(42.dp)
-                                .padding(bottom = 10.dp)
-                        )
-                    }
+                    false -> Text(
+                        text = title,
+                        color = Main2,
+                        style = OffroadTheme.typography.textRegular,
+                        modifier = Modifier
+                            .align(Alignment.CenterHorizontally)
+                            .padding(top = 10.dp, bottom = 6.dp)
+                    )
                 }
+                Text(
+                    text = content,
+                    color = Main2,
+                    style = OffroadTheme.typography.textRegular,
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .padding(bottom = 22.dp),
+                    textAlign = TextAlign.Center,
+                )
                 Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                     LogoutButton(
                         text = cancelButtonText,

--- a/feature/diary/src/main/java/com/teamoffroad/feature/diary/presentation/DiaryViewModel.kt
+++ b/feature/diary/src/main/java/com/teamoffroad/feature/diary/presentation/DiaryViewModel.kt
@@ -48,11 +48,13 @@ class DiaryViewModel @Inject constructor(
     fun getDiaryFirstDate() {
         viewModelScope.launch {
             getDiaryFirstDateUseCase.invoke().onSuccess { diaryFirstDate ->
-                if (diaryFirstDate != null) {
+                if (diaryFirstDate != null && diaryFirstDate.year != 0 && diaryFirstDate.month != 0) {
                     _diaryUiState.value = diaryUiState.value.copy(
                         diaryFirstCreatedDate = Pair(diaryFirstDate.year, diaryFirstDate.month)
                     )
                     changeDiaryShownState(diaryFirstDate)
+                } else {
+                    changeDiaryShownState(null)
                 }
             }.onFailure {
                 changeDiaryShownState(null)

--- a/feature/diary/src/main/java/com/teamoffroad/feature/diary/presentation/DiaryViewModel.kt
+++ b/feature/diary/src/main/java/com/teamoffroad/feature/diary/presentation/DiaryViewModel.kt
@@ -54,17 +54,19 @@ class DiaryViewModel @Inject constructor(
                     )
                     changeDiaryShownState(diaryFirstDate)
                 }
+            }.onFailure {
+                changeDiaryShownState(null)
             }
         }
     }
 
-    private fun changeDiaryShownState(state: DiaryFirstDate) {
+    private fun changeDiaryShownState(state: DiaryFirstDate?) {
         viewModelScope.launch {
             _diaryUiState.value = diaryUiState.value.copy(
-                diaryShown = if (state.year == 0)
-                    DiaryShownState.DiaryEmpty
-                else
+                diaryShown = if (state != null)
                     DiaryShownState.DiaryShown
+                else
+                    DiaryShownState.DiaryEmpty
             )
         }
     }

--- a/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/HomeScreen.kt
+++ b/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/HomeScreen.kt
@@ -42,6 +42,7 @@ import com.teamoffroad.characterchat.presentation.MainCharacterChatViewModel
 import com.teamoffroad.characterchat.presentation.component.ShowCharacterChat
 import com.teamoffroad.characterchat.presentation.component.ShowUserChat
 import com.teamoffroad.characterchat.presentation.model.CharacterChatLastUnreadUiState
+import com.teamoffroad.core.designsystem.component.OrbDialog
 import com.teamoffroad.core.designsystem.component.actionBarPadding
 import com.teamoffroad.feature.home.domain.model.UserQuests
 import com.teamoffroad.feature.home.presentation.component.CloseCompleteRequest
@@ -73,6 +74,7 @@ fun HomeScreen(
     val isCompleteQuestDialogShown = remember { mutableStateOf(false) }
     val characterName = homeViewModel.characterName.collectAsStateWithLifecycle()
     val newDiaryExist = homeViewModel.newDiaryExist.collectAsStateWithLifecycle()
+    val diaryCreate = homeViewModel.diaryCreateState.collectAsStateWithLifecycle()
     val launcher =
         rememberLauncherForActivityResult(contract = ActivityResultContracts.RequestPermission()) {}
 
@@ -141,6 +143,22 @@ fun HomeScreen(
             isCompleteQuestDialogShown = isCompleteQuestDialogShown,
             completeQuests = completeQuests,
             onClickCancel = { isCompleteQuestDialogShown.value = false },
+        )
+    }
+
+    if (diaryCreate.value) {
+        OrbDialog(
+            title = stringResource(id = R.string.home_diary_create_title),
+            content = stringResource(id = R.string.home_diary_create_content),
+            cancelButtonText = stringResource(id = R.string.home_diary_create_cancel),
+            nextButtonText = stringResource(id = R.string.home_confirm),
+            onClick = {
+                if (!newDiaryExist.value) navigateToDiary(true)
+                homeViewModel.updateDiaryCreateDialogUnShown()
+            },
+            onCancelClick = {
+                homeViewModel.updateDiaryCreateDialogUnShown()
+            }
         )
     }
 

--- a/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/HomeViewModel.kt
@@ -1,8 +1,10 @@
 package com.teamoffroad.feature.home.presentation
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.teamoffroad.characterchat.domain.repository.CharacterChatRepository
+import com.teamoffroad.core.common.domain.model.DiaryCreateNotificationEvent
 import com.teamoffroad.core.common.domain.repository.TokenRepository
 import com.teamoffroad.core.common.domain.usecase.SetAutoSignInUseCase
 import com.teamoffroad.feature.diary.domain.usecase.GetDiaryCheckLatestUseCase
@@ -19,6 +21,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import org.greenrobot.eventbus.EventBus
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
 import javax.inject.Inject
 
 @HiltViewModel
@@ -69,6 +74,20 @@ class HomeViewModel @Inject constructor(
 
     private val _newDiaryExist = MutableStateFlow(true)
     val newDiaryExist = _newDiaryExist.asStateFlow()
+
+    init {
+        EventBus.getDefault().register(this)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        EventBus.getDefault().unregister(this)
+    }
+
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    fun onNotificationEvent(event: DiaryCreateNotificationEvent) {
+        Log.d("characterChat data diary create ", "asdas")
+    }
 
     fun getUsersAdventuresInformation(category: String) {
         viewModelScope.launch {

--- a/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/HomeViewModel.kt
@@ -67,7 +67,7 @@ class HomeViewModel @Inject constructor(
     private val _characterName = MutableStateFlow("")
     val characterName = _characterName.asStateFlow()
 
-    private val _newDiaryExist = MutableStateFlow(false)
+    private val _newDiaryExist = MutableStateFlow(true)
     val newDiaryExist = _newDiaryExist.asStateFlow()
 
     fun getUsersAdventuresInformation(category: String) {
@@ -169,7 +169,6 @@ class HomeViewModel @Inject constructor(
     }
 
     fun getDiaryCheckLatest() {
-        //TODO. 최신일기 확인여부반환
         viewModelScope.launch {
             getDiaryCheckLatestUseCase.invoke().onSuccess {
                 if (it != null) {

--- a/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/HomeViewModel.kt
@@ -89,7 +89,10 @@ class HomeViewModel @Inject constructor(
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onNotificationEvent(event: DiaryCreateNotificationEvent) {
-        viewModelScope.launch { _diaryCreateState.emit(event.state) }
+        viewModelScope.launch {
+            getDiaryCheckLatest()
+            _diaryCreateState.emit(event.state)
+        }
     }
 
     fun getUsersAdventuresInformation(category: String) {

--- a/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/teamoffroad/feature/home/presentation/HomeViewModel.kt
@@ -75,6 +75,9 @@ class HomeViewModel @Inject constructor(
     private val _newDiaryExist = MutableStateFlow(true)
     val newDiaryExist = _newDiaryExist.asStateFlow()
 
+    private val _diaryCreateState = MutableStateFlow(false)
+    val diaryCreateState = _diaryCreateState.asStateFlow()
+
     init {
         EventBus.getDefault().register(this)
     }
@@ -86,7 +89,7 @@ class HomeViewModel @Inject constructor(
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onNotificationEvent(event: DiaryCreateNotificationEvent) {
-        Log.d("characterChat data diary create ", "asdas")
+        viewModelScope.launch { _diaryCreateState.emit(event.state) }
     }
 
     fun getUsersAdventuresInformation(category: String) {
@@ -199,6 +202,12 @@ class HomeViewModel @Inject constructor(
 
     fun initUserDiarySetting() {
         viewModelScope.launch { runCatching { diarySettingUseCase.invoke() } }
+    }
+
+    fun updateDiaryCreateDialogUnShown() {
+        viewModelScope.launch {
+            _diaryCreateState.emit(false)
+        }
     }
 
     companion object {

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -24,4 +24,8 @@
     <string name="fail_create_uri">URI 생성 실패</string>
     <string name="success_upload_image">이미지 업로드에 성공했습니다.</string>
     <string name="fail_upload_image">이미지 업로드에 실패했습니다.</string>
+
+    <string name="home_diary_create_title">일기 완성!</string>
+    <string name="home_diary_create_content">오늘의 일기가 완되었어요.\n기억빛과 함께 하루를 돌아보세요.</string>
+    <string name="home_diary_create_cancel">나중에</string>
 </resources>

--- a/feature/main/src/main/java/com/teamoffroad/feature/main/CharacterChatBroadcastReceiver.kt
+++ b/feature/main/src/main/java/com/teamoffroad/feature/main/CharacterChatBroadcastReceiver.kt
@@ -6,8 +6,10 @@ import android.content.Context.RECEIVER_EXPORTED
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Build
+import com.teamoffroad.core.common.domain.model.DiaryCreateNotificationEvent
 import com.teamoffroad.core.common.domain.model.FcmNotificationKey.ACTION_ANNOUNCEMENT_FOREGROUND
 import com.teamoffroad.core.common.domain.model.FcmNotificationKey.ACTION_CHARACTER_CHAT_FOREGROUND
+import com.teamoffroad.core.common.domain.model.FcmNotificationKey.ACTION_DIARY_CREATE_FOREGROUND
 import com.teamoffroad.core.common.domain.model.FcmNotificationKey.KEY_BODY
 import com.teamoffroad.core.common.domain.model.FcmNotificationKey.KEY_ID
 import com.teamoffroad.core.common.domain.model.FcmNotificationKey.KEY_TITLE
@@ -19,7 +21,6 @@ class CharacterChatBroadcastReceiver(
     private val navigateToAnnouncement: (id: String) -> Unit,
 ) : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-
         when (intent.action) {
             ACTION_ANNOUNCEMENT_FOREGROUND -> {
                 val announcementID = intent.getStringExtra(KEY_ID)
@@ -30,6 +31,10 @@ class CharacterChatBroadcastReceiver(
 
             ACTION_CHARACTER_CHAT_FOREGROUND -> {
                 updateCharacterChatReceived(intent)
+            }
+
+            ACTION_DIARY_CREATE_FOREGROUND -> {
+                updateDiaryCreateReceived()
             }
         }
     }
@@ -43,11 +48,16 @@ class CharacterChatBroadcastReceiver(
             .post(NotificationEvent(notificationTitle, notificationBody, notificationType))
     }
 
+    private fun updateDiaryCreateReceived() {
+        EventBus.getDefault().post(DiaryCreateNotificationEvent(true))
+    }
+
     companion object {
         fun register(context: Context, receiver: CharacterChatBroadcastReceiver) {
             val intentFilter = IntentFilter().apply {
                 addAction(ACTION_ANNOUNCEMENT_FOREGROUND)
                 addAction(ACTION_CHARACTER_CHAT_FOREGROUND)
+                addAction(ACTION_DIARY_CREATE_FOREGROUND)
             }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 context.registerReceiver(receiver, intentFilter, RECEIVER_EXPORTED)

--- a/feature/main/src/main/java/com/teamoffroad/feature/main/FcmBroadcastReceiver.kt
+++ b/feature/main/src/main/java/com/teamoffroad/feature/main/FcmBroadcastReceiver.kt
@@ -17,7 +17,7 @@ import com.teamoffroad.core.common.domain.model.FcmNotificationKey.KEY_TYPE
 import com.teamoffroad.core.common.domain.model.NotificationEvent
 import org.greenrobot.eventbus.EventBus
 
-class CharacterChatBroadcastReceiver(
+class FcmBroadcastReceiver(
     private val navigateToAnnouncement: (id: String) -> Unit,
 ) : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
@@ -53,7 +53,7 @@ class CharacterChatBroadcastReceiver(
     }
 
     companion object {
-        fun register(context: Context, receiver: CharacterChatBroadcastReceiver) {
+        fun register(context: Context, receiver: FcmBroadcastReceiver) {
             val intentFilter = IntentFilter().apply {
                 addAction(ACTION_ANNOUNCEMENT_FOREGROUND)
                 addAction(ACTION_CHARACTER_CHAT_FOREGROUND)
@@ -66,7 +66,7 @@ class CharacterChatBroadcastReceiver(
             }
         }
 
-        fun unregister(context: Context, receiver: CharacterChatBroadcastReceiver) {
+        fun unregister(context: Context, receiver: FcmBroadcastReceiver) {
             context.unregisterReceiver(receiver)
         }
     }

--- a/feature/main/src/main/java/com/teamoffroad/feature/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/teamoffroad/feature/main/MainActivity.kt
@@ -22,7 +22,7 @@ import dagger.hilt.android.AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     private val notificationTypeState = mutableStateOf<String?>(null)
     private val notificationIdState = mutableStateOf<String?>(null)
-    private lateinit var characterBroadcastReceiver: CharacterChatBroadcastReceiver
+    private lateinit var characterBroadcastReceiver: FcmBroadcastReceiver
     private val viewModel by viewModels<MainViewModel>()
     private val mainCharacterViewModel by viewModels<MainCharacterChatViewModel>()
 
@@ -30,10 +30,10 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         notificationTypeState.value = intent.getStringExtra(KEY_TYPE)
         notificationIdState.value = intent.getStringExtra(KEY_ID)
-        characterBroadcastReceiver = CharacterChatBroadcastReceiver(
+        characterBroadcastReceiver = FcmBroadcastReceiver(
             navigateToAnnouncement = viewModel::navigateToAnnouncement,
         )
-        CharacterChatBroadcastReceiver.register(this, characterBroadcastReceiver)
+        FcmBroadcastReceiver.register(this, characterBroadcastReceiver)
 
         setContent {
             val navigator: MainNavigator = rememberMainNavigator()
@@ -54,7 +54,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        CharacterChatBroadcastReceiver.unregister(this, characterBroadcastReceiver)
+        FcmBroadcastReceiver.unregister(this, characterBroadcastReceiver)
     }
 
     companion object {

--- a/feature/mypage/src/main/java/com/teamoffroad/feature/mypage/presentation/diaryTime/DiaryTimeScreen.kt
+++ b/feature/mypage/src/main/java/com/teamoffroad/feature/mypage/presentation/diaryTime/DiaryTimeScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.teamoffroad.core.designsystem.component.NavigateBackAppBar
+import com.teamoffroad.core.designsystem.component.OrbDialog
 import com.teamoffroad.core.designsystem.component.actionBarPadding
 import com.teamoffroad.core.designsystem.component.clickableWithoutRipple
 import com.teamoffroad.core.designsystem.component.navigationPadding
@@ -36,7 +37,6 @@ import com.teamoffroad.core.designsystem.theme.Main2
 import com.teamoffroad.core.designsystem.theme.OffroadTheme
 import com.teamoffroad.core.designsystem.theme.Sub2
 import com.teamoffroad.core.designsystem.theme.White
-import com.teamoffroad.feature.mypage.presentation.component.DiaryTimeDialog
 import com.teamoffroad.feature.mypage.presentation.component.DiaryTimePicker
 import com.teamoffroad.feature.mypage.presentation.component.SettingHeader
 import com.teamoffroad.offroad.feature.mypage.R
@@ -150,7 +150,7 @@ fun DiaryTimeScreen(
             DiaryTimeDialogState.InVisible -> {}
 
             DiaryTimeDialogState.BackDialogVisible ->
-                DiaryTimeDialog(
+                OrbDialog(
                     onClick = {
                         viewModel.navigateToSetting()
                     },
@@ -163,7 +163,7 @@ fun DiaryTimeScreen(
                 )
 
             DiaryTimeDialogState.NextDialogVisible ->
-                DiaryTimeDialog(
+                OrbDialog(
                     onClick = {
                         viewModel.patchDiaryCreateTime()
                         viewModel.navigateToSetting()


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #347

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 기존에 있던 FCM KEY에 MEMBER_DIARY_CREATE가 추가되었습니다.
- 백그라운드에서 알림 받을 시 -> 기존과 동일
- 포그라운드에서 알림 받을 시 -> 홈 스크린에서 다이얼로그

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

https://github.com/user-attachments/assets/d6e539b4-1c66-4d9b-89b8-03fefb065ffb


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
테스트 api에서 타입을 "MEMBER_DIARY_CREATE"로 보내면 됩니다.



